### PR TITLE
新規ユーザー登録機能を追加

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -29,7 +29,7 @@ class RegisterController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = RouteServiceProvider::HOME;
+    protected $redirectTo = '/';
 
     /**
      * Create a new controller instance.

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -19,7 +19,7 @@ class RedirectIfAuthenticated
     public function handle($request, Closure $next, $guard = null)
     {
         if (Auth::guard($guard)->check()) {
-            return redirect(RouteServiceProvider::HOME);
+            return redirect('/');
         }
 
         return $next($request);

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,13 +1,13 @@
 @extends('layouts.app')
 @section('content')
 
-<div class="text-center">
-    <div class="text-center mt-3">
+<div class="text-center mt-5">
+    <div class="text-center">
         <h1><i class="fas fa-chalkboard-teacher pr-3 d-inline"></i>Chat App</h1>
-        <div class="text-center">
-            <h3 class="login_title text-left d-inline-block mt-5">新規登録</h3>
+        <div class="text-center mt-10">
+            <h3 class="login_title text-left d-inline-block mt-10">新規登録</h3>
         </div>
-        <div class="row mt-5 mb-5">
+        <div class="row mt-50 mb-5">
             <div class="col-sm-6 offset-sm-3">
                 <form method="POST" action="{{ route('signup.post') }}">
                     @csrf
@@ -27,7 +27,7 @@
                         <label for="password_confirmation">パスワード確認</label>
                         <input id="password_confirmation" type="password" class="form-control" name="password_confirmation" value="{{ old('password_confirmation') }}">
                     </div>
-                    <button type="submit" class="btn btn-block btn-primary mt-3 mb-3">新規登録</button>
+                    <button type="submit" class="btn btn-block btn-primary mt-3">新規登録</button>
                 </form>
             </div>
         </div>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,0 +1,38 @@
+@extends('layouts.app')
+@section('content')
+
+<div class="text-center">
+    <div class="text-center mt-3">
+        <h1><i class="fas fa-chalkboard-teacher pr-3 d-inline"></i>Chat App</h1>
+        <div class="text-center">
+            <h3 class="login_title text-left d-inline-block mt-5">新規登録</h3>
+        </div>
+        <div class="row mt-5 mb-5">
+            <div class="col-sm-6 offset-sm-3">
+                <form method="POST" action="{{ route('signup.post') }}">
+                    @csrf
+                    <div class="form-group">
+                        <label for="name">名前</label>
+                        <input id="name" type="text" class="form-control" name="name" value="{{ old('name') }}">
+                    </div>
+                    <div class="form-group">
+                        <label for="email">メールアドレス</label>
+                        <input id="email" type="text" class="form-control" name="email" value="{{ old('email') }}">
+                    </div>
+                    <div class="form-group">
+                        <label for="password">パスワード</label>
+                        <input id="password" type="password" class="form-control" name="password" value="{{ old('password') }}">
+                    </div>
+                    <div class="form-group">
+                        <label for="password_confirmation">パスワード確認</label>
+                        <input id="password_confirmation" type="password" class="form-control" name="password_confirmation" value="{{ old('password_confirmation') }}">
+                    </div>
+                    <button type="submit" class="btn btn-block btn-primary mt-3 mb-3">新規登録</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+<h5 class="description text-center mt-3">チャットで会話をしましょう</h5>
+
+@endsection

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -33,6 +33,4 @@
         </div>
     </div>
 </div>
-<h5 class="description text-center mt-3">チャットで会話をしましょう</h5>
-
 @endsection

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -8,7 +8,7 @@
             <div class="container navbar-container" id="nav-bar" >
                 <ul class="navbar-nav ml-auto">
                     <li class="nav-item"><a href="" class="nav-link">ログイン</a></li>
-                    <li class="nav-item"><a href="" class="nav-link">新規登録</a></li>
+                    <li class="nav-item"><a href="{{ route('signup') }}" class="nav-link">新規登録</a></li>
                 </ul>
             </div>
         </nav>

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,3 +14,10 @@
 Route::get('/', function () {
     return view('welcome');
 });
+
+//新規登録
+Route::get('signup','Auth\RegisterController@showRegistrationForm')->name('signup');
+Route::post('signup','Auth\RegisterController@register')->name('signup.post');
+
+
+


### PR DESCRIPTION
# issue

https://github.com/Hashimoto-Noriaki/laravel-chatwork-app/issues/14

# 変更箇所
- app/Http/Controllers/Auth/RegisterController.php
- app/Http/Middleware/RedirectIfAuthenticated.php
- resources/views/auth/register.blade.php
- resources/views/commons/header.blade.php
- routes/web.php

# 動作確認
1. 下記の新規登録の画面から新規登録をする

<img width="1440" alt="スクリーンショット 2024-05-19 1 38 06" src="https://github.com/Hashimoto-Noriaki/laravel-chatwork-app/assets/73786052/b19d7612-5508-4a4e-b4ff-7704b775ef3b">

2. 完成画面から登録ができることを確認

# 完成画面
<img width="1317" alt="スクリーンショット 2024-05-19 1 26 39" src="https://github.com/Hashimoto-Noriaki/laravel-chatwork-app/assets/73786052/f15f84cc-3f0d-4cc2-9b9a-8010d331a544">

# ユーザー登録の確認

<img width="1317" alt="スクリーンショット 2024-05-19 1 26 39" src="https://github.com/Hashimoto-Noriaki/laravel-chatwork-app/assets/73786052/053ed63a-bed2-48a6-a945-d6650c82417c">

# 登録後
このissueをマージする段階では、まだログイン機能を作っていないので、ログアウトができない状態なので、
Adminerから手動で削除すると再度新規登録ができる。

# 補足
- ```app/Http/Middleware/RedirectIfAuthenticated.php```
このミドルウェアは、例えば認証済みのユーザーがログインページや新規ユーザー登録ページにアクセスしようとしたときに、それを防いでホームページなどの他のページにリダイレクトします。これにより、既にログインしているユーザーが再度ログインしようとする無駄な操作を防ぐことができます。

- ```csrf```
***form 開始タグの直後にある「@csrf」***
クロス・サイト・リクエスト・フォージェリ（CSRF）というハッキングの手口からサイトを守るための記述。

ex)
POSTメソッドなどで他の悪意あるサーバからリクエストがあった場合、Laravelがそのリクエストを正しいものと見なさないための必須の記述



