### PR TITLE
新規ユーザー登録では、パスワードを大文字、小文字、数字をそれぞれ1文字以上含めるように設定

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -52,7 +52,8 @@ class RegisterController extends Controller
         return Validator::make($data, [
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
-            'password' => ['required', 'string', 'min:8', 'confirmed'],
+            //'regex:/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]+$/'は、'regex:/[a-z]/'(小文字を含む)、'regex:/[A-Z]/'(大文字を含む)、'regex:/[0-9]/'(数字を含む)を合わせた正規表現
+            'password' => ['required', 'string', 'min:8', 'confirmed', 'regex:/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]+$/'],
         ]);
     }
 

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -38,6 +38,7 @@ class UsersController extends Controller
         $user->email = $request->email;
         $user->password = bcrypt($request->password);
         $user->save();
+
         return redirect()->route('users.show', ['id' => $id]);
     }
 

--- a/resources/lang/ja/validation.php
+++ b/resources/lang/ja/validation.php
@@ -95,7 +95,7 @@ return [
     'numeric' => ':attributeには、数字を指定してください。',
     'password' => ':attributeが間違っています',
     'present' => ':attributeが存在している必要があります。',
-    'regex' => ':attributeには、有効な正規表現を指定してください。',
+    'regex' => ':attributeには、大文字、小文字、数字をそれぞれ1文字以上含める必要があります。',
     'required' => ':attributeは、必ず指定してください。',
     'required_if' => ':otherが:valueの場合、:attributeを指定してください。',
     'required_unless' => ':otherが:values以外の場合、:attributeを指定してください。',


### PR DESCRIPTION
# issue
https://github.com/Hashimoto-Noriaki/laravel-chatwork-app/issues/52#issue-2317403165

# 変更点
- app/Http/Controllers/Auth/RegisterController.php
- app/Http/Controllers/UsersController.php
- resources/lang/ja/validation.php

# 動作確認
パスワードをj123456789を入れたら以下のような画面に変わった。

<img width="1434" alt="スクリーンショット 2024-05-29 3 15 48" src="https://github.com/Hashimoto-Noriaki/laravel-chatwork-app/assets/73786052/87db4f3c-f499-4dbb-aaf9-71014e0ff094">
